### PR TITLE
feat: 낙상 감지 후 낙상 확정 로직 추가

### DIFF
--- a/src/fall_logic.py
+++ b/src/fall_logic.py
@@ -10,6 +10,7 @@ class FallDetectorLogic:
         self.VELOCITY_THRESHOLD = 150 #낙상으로 판단할 Y축 속도의 임계값 설정 (픽셀/초)
         self.ASPECT_RATIO_THRESHOLD = 1.0 #낙상으로 판단할 가로/세로 비율 임계값 설정 (x변화량/y변화량) 
         self.STILLNESS_TIME_THRESHOLD = 3 #낙상 후 움직임이 없어야 하는 최소 시간 설정 
+        self.STILLNESS_Y_THRESHOLD = 5 #움직임 없음으로 판단할 픽셀 변화 임계값
 
     #매 프레임마다 YOLO 감지 결과(detection)를 처리하고 낙상 지표를 계산하는 메서드
     def process_detection(self, track_id, bbox, current_time):
@@ -23,8 +24,6 @@ class FallDetectorLogic:
             self.person_states[track_id] = {
                 'last_y': current_center_y,
                 'last_time': current_time,
-                'last_width': width,
-                'last_height': height,
                 'status': 'Standing',
                 'fall_start_time': None
             }
@@ -45,23 +44,56 @@ class FallDetectorLogic:
         # 2. 바운딩 박스 비율을 이용한 쓰러짐 감지 (x변화량/y변화량 > 1.0)
         is_horizontal = aspect_ratio > self.ASPECT_RATIO_THRESHOLD
 
-        # 상태 갱신 로직 
-        new_status = state['status']
-        if is_high_velocity_fall:
-            new_status = 'Potential Fall'
-        elif is_horizontal:
-            new_status = 'Lying'
-        elif not is_high_velocity_fall and not is_horizontal:
-            if current_center_y < (state['last_y'] - 50) and abs(velocity_y) < 5:
-                new_status = 'Sitting'
+        # 현재 정지 상태인지 확인 
+        is_currently_still = abs(dy) < self.STILLNESS_Y_THRESHOLD
+
+        # -----------------------------------------------------------------
+        # 상태 갱신 로직 (정지 시간 추적 추가)
+        # -----------------------------------------------------------------
+
+        current_status = state['status']
+        fall_start_time = state['fall_start_time']
+
+        # 1. 초기 낙상 감지: 속도가 빠르거나, 현재 Potential Fall 상태가 아니라면
+        if is_high_velocity_fall and current_status not in ['Potential Fall', 'Fall Detected!']:
+            current_status = 'Potential Fall'
+            fall_start_time = current_time  # 타이머 시작
+        
+        # 2. Potential Fall 상태 처리
+        if current_status == 'Potential Fall':
+            
+            # 누워있는 상태(is_horizontal)가 지속되어야 최종 판단 진행
+            if is_horizontal:
+                # 정지 상태가 충분한 시간(3초) 이상 지속되었는지 확인
+                if is_currently_still and (current_time - fall_start_time) >= self.STILLNESS_TIME_THRESHOLD:
+                    current_status = 'Fall Detected!' # 최종 낙상 사고 확정
+                    fall_start_time = None # 타이머 초기화 (더 이상 필요 없음)
+                # 정지 상태가 아니라면 타이머는 계속 흐르거나, 리셋될 수 있음 (단순히 이탈 방지)
+                # 여기서는 타이머가 흐르도록 유지
             else:
-                new_status = 'Standing'
+                # 속도는 빨랐지만 다시 서거나 앉은 자세로 돌아간 경우 (오경보)
+                current_status = 'Standing'
+                fall_start_time = None # 타이머 리셋
+
+        # 3. 일반 상태 (낙상이 아닌 경우)
+        elif current_status not in ['Potential Fall', 'Fall Detected!']:
+            if is_horizontal:
+                current_status = 'Lying'  # 단순히 누워있는 자세
+            elif current_center_y < (state['last_y'] - 50) and abs(velocity_y) < 5:
+                current_status = 'Sitting' # 앉은 자세
+            else:
+                current_status = 'Standing'
+            fall_start_time = None # 타이머 리셋
+
+        # 4. Fall Detected! 상태에서는 계속 유지
+        elif current_status == 'Fall Detected!':
+             # 사고가 확정되었으므로 상태를 유지 (알림 후 수동 리셋 필요)
+            pass 
         
         #상태 정보 업데이트
         state['last_y'] = current_center_y
         state['last_time'] = current_time
-        state['last_width'] = width
-        state['last_height'] = height
-        state['status'] = new_status
+        state['status'] = current_status
+        state['fall_start_time'] = fall_start_time
 
-        return new_status #최종 상태 반환
+        return current_status #최종 상태 반환


### PR DESCRIPTION
## 📝작업 내용

- 낙상으로 감지된 후 일정 시간 동안 움직임이 없는지를 확인하는 정지 시간 추적 기능을 추가하여 최종 낙상 사고 확정의 정확도를 높임
- self.STILLNESS_TIME_THRESHOLD (3초): 낙상 사고를 확정하는 데 필요한 최소 정지 시간을 설정했습니다.
- self.STILLNESS_Y_THRESHOLD (5픽셀): 중심점의 Y 좌표 변화가 이 값 이내일 때 '정지 상태'로 간주합니다.
- 상태 전환 로직 수정:
    - 'Potential Fall': 급격한 속도 또는 누운 자세가 감지되면 타이머(fall_start_time)를 시작하며 이 상태로 진입합니다.
    - 'Fall Detected!': 'Potential Fall' 상태에서 설정된 시간(3초) 동안 움직임이 없고 (Stillness), **누워있는 자세(is_horizontal)** 가 유지될 때만 최종적으로 확정됩니다.
    - 오탐지 회피: 속도는 빨랐으나 다시 정상 자세로 돌아온 경우, 타이머를 리셋하고 'Standing'으로 복귀시켜 오탐지를 방지합니다.